### PR TITLE
Remove the erroneous comment at the start of the file

### DIFF
--- a/demo3_1.asm
+++ b/demo3_1.asm
@@ -1,4 +1,4 @@
-The internal loop should fit	;
+	;
 	; Horizontal positioning demo (Chapter 3 section 1)
 	;
 	; by Oscar Toledo G.


### PR DESCRIPTION
I noticed that there is a misplaced line of text before the header. I removed it since it breaks the assembler.

Thanks for a great book -- a true joy to work through 👍